### PR TITLE
failover: pass error that caused disconnect to `OnDisconnect()`

### DIFF
--- a/failover/failover_electrum_test.go
+++ b/failover/failover_electrum_test.go
@@ -166,7 +166,8 @@ func (s *electrumTestsuite) SetupTest() {
 		StartIndex:   func() int { return 0 },
 		RetryTimeout: time.Millisecond,
 		OnConnect:    func(server *Server[*electrum.Client]) {},
-		OnDisconnect: func(server *Server[*electrum.Client]) {
+		OnDisconnect: func(server *Server[*electrum.Client], err error) {
+			require.Error(s.T(), err)
 			count := s.onDisconnectCount.Add(1)
 			onDisconnect := s.onDisconnect.get()
 			if onDisconnect != nil {

--- a/failover/failover_test.go
+++ b/failover/failover_test.go
@@ -127,7 +127,9 @@ func (s *testSuite) SetupTest() {
 		OnConnect: func(server *Server[*client]) {
 
 		},
-		OnDisconnect: func(server *Server[*client]) {},
+		OnDisconnect: func(server *Server[*client], err error) {
+			require.Error(s.T(), err)
+		},
 		OnRetry: func(err error) {
 			onRetry := s.onRetry.get()
 			if onRetry != nil {


### PR DESCRIPTION
Helpful information to display to a user or to log in a log file.